### PR TITLE
Set up the ENV variable in the profile

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ touch ~/.git-author
 
 git config --global commit.template ~/.git-author
 
-cat >> ~/.bashrc <<EOL
+cat >> ~/.bash_profile <<EOL
 
 # disable --signoff called by 'git-together commit'
 export GIT_TOGETHER_NO_SIGNOFF=1


### PR DESCRIPTION
If someone opens up a subshell (non-login), we expect that it will
inherit env variables as appropriate. So bash_profile would be better

Author: C.J. Jameson <cjameson@pivotal.io>