### PR TITLE
Append $STORY_NUM to the git author commit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ A simple tool to add multiple authors to commit mesages. Under the hood it is
 based on `git commit --template` and depends on `git-together`.
 
 # Setup
-1. Follow the instructions from https://github.com/kejadlen/git-together to set up
-   the `git-together` configurations.
+1. Follow the instructions from https://github.com/kejadlen/git-together to set
+   up the `git-together` configurations.
 2. Run `setup.sh`.
 3. Add `export GIT_TOGETHER_NO_SIGNOFF=1` to your environment (e.g. in
    `~/.bashrc` on Linux or `~/.bash_profile` on MacOS). This will disable the
@@ -12,6 +12,7 @@ based on `git commit --template` and depends on `git-together`.
 
 # Usage
 Set the authors as below:
+
 ```
 # pairing with James and Naomi
 git author jh nn
@@ -27,8 +28,8 @@ git author
 ```
 
 After doing so, `git commit` will now automatically include all of the authors
-in the commit message with the prefix `Co-authored-by:` or `Authored-by` if there
-is only one author. For example:
+in the commit message with the prefix `Co-authored-by:` or `Authored-by` if
+there is only one author. For example:
 
 ```
 # mobbing
@@ -56,6 +57,24 @@ git commit
 
 Authored-by: Chrisjen Avasarala <avasarala@un.gov>
 ```
+
+## Story Numbers
+Often when making commits, we like to append the commit message with a story
+number, e.g. `[#12345678]`. To automate this process, you can set the
+`$STORY_NUM` environment variable to a value such as `'#12345678 story title'`.
+This will result in the below being appended to the commit message template:
+
+```
+[#12345678]
+# story title
+
+Co-authored-by: ...
+Co-authored-by: ...
+```
+
+Additionally, if you set `git config --global git-author.includeBlankStoryNum true`,
+then if you didn't set `$STORY_NUM`, empty story number brackets ('[]') will be
+appended to prompt you to fill it in.
 
 # Why
 `git-together` is a wonderful tool to change the `author` and `commit` fields

--- a/git-author
+++ b/git-author
@@ -2,15 +2,35 @@
 
 git_author_file_name=~/.git-author
 
-if [ -n "$1" ] ; then
-	echo $'\n' > $git_author_file_name
-	if [ $# == 1 ]; then
-		git-together with $@ | sed "s/.*/Authored-by: &/" >> $git_author_file_name
+print_story_num()
+{
+	if [ "$(git config git-author.includeBlankStoryNum)" = 'true' \
+	     -o -n "$STORY_NUM" ] ; then
+		<<<"$STORY_NUM" read story_num story_comment
+		echo "[$story_num]"
+		echo "# $story_comment"
+		echo ""
+	fi
+}
+
+insert_author_tags()
+{
+	local number_of_authors="$1"
+	if [ "$number_of_authors" -eq 1 ] ; then
+		sed "s/.*/Authored-by: &/"
 	else
-		git-together with $@ | sed "s/.*/Co-authored-by: &/" >> $git_author_file_name
-	fi;
+		sed "s/.*/Co-authored-by: &/"
+	fi
+}
+
+if [ -n "$1" ] ; then
+	(
+		echo ""
+		echo ""
+		print_story_num
+		git-together with "$@" | insert_author_tags $#
+	) > "$git_author_file_name"
 fi
 
-# Do not print blank lines because it's clutter on the terminal
-<$git_author_file_name awk '!/^$/{print}'
-
+# Echo the script, but do not print blank lines because it's clutter on the terminal
+<"$git_author_file_name" awk '!/^$/{print}'


### PR DESCRIPTION
Also adds the optional git-author.includeBlankStoryNum git config option
and documentation for how to use $STORY_NUM.

Author: David Sharp <dsharp@pivotal.io>
Author: Amil Khanzada <akhanzada@pivotal.io>