### PR TITLE
Write "Authored-by" if only one person is committing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ git author
 ```
 
 After doing so, `git commit` will now automatically include all of the authors
-in the commit message with the prefix `Co-authored-by:`. For example:
+in the commit message with the prefix `Co-authored-by:` or `Authored-by` if there
+is only one author. For example:
 
 ```
 # mobbing
@@ -42,6 +43,18 @@ git commit
 Co-authored-by: James Holden <jholden@rocinante.com>
 Co-authored-by: Naomi Nagata <nnagata@rocinante.com>
 Co-authored-by: Chrisjen Avasarala <avasarala@un.gov>
+
+
+# soloing
+git author ca
+
+# commit
+git commit
+
+# the commit message is pre-populated as:
+
+
+Authored-by: Chrisjen Avasarala <avasarala@un.gov>
 ```
 
 # Why

--- a/git-author
+++ b/git-author
@@ -4,7 +4,11 @@ git_author_file_name=~/.git-author
 
 if [ -n "$1" ] ; then
 	echo $'\n' > $git_author_file_name
-	git-together with $@ | sed "s/.*/Co-authored-by: &/" >> $git_author_file_name
+	if [ $# == 1 ]; then
+		git-together with $@ | sed "s/.*/Authored-by: &/" >> $git_author_file_name
+	else
+		git-together with $@ | sed "s/.*/Co-authored-by: &/" >> $git_author_file_name
+	fi;
 fi
 
 # Do not print blank lines because it's clutter on the terminal


### PR DESCRIPTION
We don't need the "Co-authored-by" keyword if only one person is committing, and it is somewhat confusing. We set the template to say "Authored-by" instead for this case.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>